### PR TITLE
Fix useradd call and ensure lazy map eval happens

### DIFF
--- a/authorized-keys-iam.py
+++ b/authorized-keys-iam.py
@@ -16,6 +16,7 @@ Options:
 
 """
 from docopt import docopt
+from subprocess import call
 
 import boto3
 import sys
@@ -42,13 +43,13 @@ def get_missing_users():
   iam_users = client.list_users()["Users"]
   system_users = map(lambda x: x.pw_name, pwd.getpwall())
   for user in iam_users:
-    if user not in system_users:
-      missing.append(user)
+    if user["UserName"] not in system_users:
+      missing.append(user["UserName"])
 
   return missing
 
 def add_user(user):
-  call("/usr/sbin/adduser " + shlex.quote(user))
+  call(["/usr/sbin/adduser", "--shell=/bin/bash", "--disabled-password", "--quiet", "--gecos=\"\"", shlex.quote(user)])
 
 if __name__ == '__main__':
   arguments = docopt(__doc__, version="Authorized Keys IAM 0.1")
@@ -56,4 +57,4 @@ if __name__ == '__main__':
     user = arguments["<user>"]
     print_user_keys(user)
   elif arguments["sync-users"]:
-    map(add_user, get_missing_users())
+    list(map(add_user, get_missing_users()))


### PR DESCRIPTION
In python 3 map is lazy evaluated, so if you don't iterate it, then you
will never execute the function. So this casting it to a list will step
through the iterator.

The useradd call didn't have the needed params, first it needed to not
set any of the user data since that is asked in stdin. It could
potentially be grabbed from AWS IAM.

The shell needs to be set so they are actually dropped into a shell when
they try to login.

Disabling the password prompt since they will login with keys.